### PR TITLE
center empty template in feedback list

### DIFF
--- a/client/src/app/feedback-list/feedback-list.component.css
+++ b/client/src/app/feedback-list/feedback-list.component.css
@@ -20,10 +20,11 @@ a {
     margin-left: 120px;
 }
 .empty {
-    padding: 1rem;
     border: 0.5px solid #ccc;
     align-self: center;
     text-align: center;
+    padding: 250px;
+    margin-left: 100px;
 }
 h4 {
     font-weight: 400;
@@ -52,6 +53,10 @@ h4:nth-child(2) {
         margin-top: 20px;
         margin-left: 10px;
     }
+    .empty {
+        padding: 200px;
+        margin-left: 50px;
+    }
   
 }
 @media screen and (max-width: 550px) {
@@ -60,6 +65,7 @@ h4:nth-child(2) {
         position: absolute;
         margin-left: 340px;
     }
+  
 }
 @media screen and (max-width: 512px) {
 .content {
@@ -71,6 +77,10 @@ h4:nth-child(2) {
     position: absolute;
     margin-left: 240px;
 }
+.empty {
+    padding: 150px;
+    margin-left: 0;
+}
 
 }
 @media screen and (max-width: 400px) {
@@ -78,6 +88,9 @@ h4:nth-child(2) {
         margin-top: 5px;
         position: absolute;
         margin-left: 200px;
+    }
+    .empty {
+        padding: 100px;
     }
     
     }


### PR DESCRIPTION
changement: centrer le label Aucun feedback

Avant:
<img width="1062" alt="Screenshot 2022-07-27 at 13 49 15" src="https://user-images.githubusercontent.com/47147025/181239694-e9c276fd-053c-44bb-9322-248601ecfea4.png">



Maintenant:
<img width="1101" alt="Screenshot 2022-07-27 at 12 10 53" src="https://user-images.githubusercontent.com/47147025/181239495-83bb6f6e-ba93-4ea3-9438-f25f29cf3fcb.png">

