### PR TITLE
add unit tests in feedback list component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -46,7 +46,7 @@
         "@angular/cli": "~13.3.0",
         "@angular/compiler-cli": "~13.3.0",
         "@types/jasmine": "~3.10.0",
-        "@types/jest": "^27.4.1",
+        "@types/jest": "^27.5.2",
         "@types/node": "^12.11.1",
         "@typescript-eslint/eslint-plugin": "5.17.0",
         "@typescript-eslint/parser": "5.17.0",
@@ -5287,9 +5287,9 @@
       "dev": true
     },
     "node_modules/@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "devOptional": true,
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
@@ -23673,9 +23673,9 @@
       "dev": true
     },
     "@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "devOptional": true,
       "requires": {
         "jest-matcher-utils": "^27.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
     "@angular/cli": "~13.3.0",
     "@angular/compiler-cli": "~13.3.0",
     "@types/jasmine": "~3.10.0",
-    "@types/jest": "^27.4.1",
+    "@types/jest": "^27.5.2",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "5.17.0",
     "@typescript-eslint/parser": "5.17.0",

--- a/client/src/app/feedback-list/feedback-list.component.css
+++ b/client/src/app/feedback-list/feedback-list.component.css
@@ -42,9 +42,6 @@ h4:nth-child(2) {
     font-size: 0.8rem;
     color: grey;
 }
-.test {
-    
-}
 
 @media screen and (max-width: 690px) {
     h4:nth-child(2) {

--- a/client/src/app/feedback-list/feedback-list.component.css
+++ b/client/src/app/feedback-list/feedback-list.component.css
@@ -42,6 +42,9 @@ h4:nth-child(2) {
     font-size: 0.8rem;
     color: grey;
 }
+.test {
+    
+}
 
 @media screen and (max-width: 690px) {
     h4:nth-child(2) {

--- a/client/src/app/feedback-list/feedback-list.component.spec.ts
+++ b/client/src/app/feedback-list/feedback-list.component.spec.ts
@@ -75,12 +75,12 @@ describe('FeedbackListComponent', () => {
     await fixture.whenStable()
     expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Sent`)
   }) 
-  it('should open the feedback detail of a recivied feedback when the sender name is clicked in the list', ()=> {
+  it('should open the feedback detail of a recivied feedback when the sender name is clicked in the list', async ()=> {
     component.type = FeedbackType.Received
     fixture.detectChanges();
     fixture.debugElement.query(By.css('a')).nativeElement.click(); 
-    fixture.whenStable().then(() => {
-      expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Received`)
-      })
+    await fixture.whenStable()
+    expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Received`)
+      
   })
 });

--- a/client/src/app/feedback-list/feedback-list.component.spec.ts
+++ b/client/src/app/feedback-list/feedback-list.component.spec.ts
@@ -1,19 +1,29 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FeedbackType } from '../enum/feedback-type';
 import { Feedback } from '../model/feedback';
 import { Nl2brPipe } from '../pipe/nl2br/nl2br.pipe';
-
+import { FeedbackComponent } from '../feedback/feedback.component';
 import { FeedbackListComponent } from './feedback-list.component';
+import { Location } from '@angular/common';
 
 describe('FeedbackListComponent', () => {
   let component: FeedbackListComponent;
   let fixture: ComponentFixture<FeedbackListComponent>;
-
+  let location: Location;
+  let router: Router;
+  const routes: Routes = [
+    {path:'feedback/:id/:type',component:FeedbackComponent},
+  ];
+  const feedbacks: Feedback[] = [ new Feedback('123', 'token', 'Pierre',
+      'pierre@example.com', 'marie@example.com', 'marie')]
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule,
+        RouterTestingModule.withRoutes(routes)],
       declarations: [
         FeedbackListComponent,
         Nl2brPipe
@@ -23,13 +33,55 @@ describe('FeedbackListComponent', () => {
   });
 
   beforeEach(() => {
+    router = TestBed.get(Router);
+    location = TestBed.get(Location);
     fixture = TestBed.createComponent(FeedbackListComponent);
     component = fixture.componentInstance;
-    component.type = FeedbackType.Received
+    component.feedbacks = feedbacks
+    component.type = FeedbackType.Sent
+    router.initialNavigation();
     fixture.detectChanges();
   });
-
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+  it('should show the empty template when feedbacks list is null' ,() => {
+    component.feedbacks = []
+    fixture.detectChanges()
+    const emptyTemplate = fixture.debugElement.query(By.css('.empty'))
+    expect(emptyTemplate).toBeTruthy()
+  });
+  it('empty template should be disapeared when the feedback list is not null', ()=> {
+      const emptyTemplate = fixture.debugElement.query(By.css('.empty'))
+      expect(emptyTemplate).toBeFalsy()
+  });
+  it('the feedback list will be appeared when the list contains feedbacks', ()=> {
+    const feedbackList = fixture.debugElement.query(By.css('.list'))
+    expect(feedbackList).toBeTruthy()
+  });
+  it('should show the sent feedbacks when the feedzbacks envoyés tab is clicked', ()=> {
+    const senderName = fixture.debugElement.query(By.css('a'))
+    expect(senderName.nativeElement.textContent.trim()).toEqual(feedbacks[0].receverName)
+  });
+  it('should show the recevied feedbacks when the feedzbacks reçus tab is clicked', ()=> {
+    component.type = FeedbackType.Received
+    fixture.detectChanges()
+    const senderName = fixture.debugElement.query(By.css('a'))
+    expect(senderName.nativeElement.textContent.trim()).toEqual(feedbacks[0].senderName)
+  });
+  it('should open the feedback detail of a sent feedback when the recevier name is clicked in the list', ()=> {
+    fixture.debugElement.query(By.css('a')).nativeElement.click(); 
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Sent`)
+      })
+  }) 
+  it('should open the feedback detail of a recivied feedback when the sender name is clicked in the list', ()=> {
+    component.type = FeedbackType.Received
+    fixture.detectChanges();
+    fixture.debugElement.query(By.css('a')).nativeElement.click(); 
+    fixture.whenStable().then(() => {
+      expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Received`)
+      })
+  })
 });

--- a/client/src/app/feedback-list/feedback-list.component.spec.ts
+++ b/client/src/app/feedback-list/feedback-list.component.spec.ts
@@ -69,12 +69,11 @@ describe('FeedbackListComponent', () => {
     const senderName = fixture.debugElement.query(By.css('a'))
     expect(senderName.nativeElement.textContent.trim()).toEqual(feedbacks[0].senderName)
   });
-  it('should open the feedback detail of a sent feedback when the recevier name is clicked in the list', ()=> {
+  it('should open the feedback detail of a sent feedback when the recevier name is clicked in the list', async ()=> {
     fixture.debugElement.query(By.css('a')).nativeElement.click(); 
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Sent`)
-      })
+    await fixture.whenStable()
+    expect(location.path()).toEqual(`/feedback/${feedbacks[0].id}/Sent`)
   }) 
   it('should open the feedback detail of a recivied feedback when the sender name is clicked in the list', ()=> {
     component.type = FeedbackType.Received

--- a/client/src/app/feedback-list/feedback-list.component.spec.ts
+++ b/client/src/app/feedback-list/feedback-list.component.spec.ts
@@ -61,13 +61,13 @@ describe('FeedbackListComponent', () => {
   });
   it('should show the sent feedbacks when the feedzbacks envoyés tab is clicked', ()=> {
     const senderName = fixture.debugElement.query(By.css('a'))
-    expect(senderName.nativeElement.textContent.trim()).toEqual(feedbacks[0].receverName)
+    expect(senderName.nativeElement.textContent).toContain(feedbacks[0].receverName)
   });
   it('should show the recevied feedbacks when the feedzbacks reçus tab is clicked', ()=> {
     component.type = FeedbackType.Received
     fixture.detectChanges()
     const senderName = fixture.debugElement.query(By.css('a'))
-    expect(senderName.nativeElement.textContent). toContain(feedbacks[0].senderName)
+    expect(senderName.nativeElement.textContent).toContain(feedbacks[0].senderName)
   });
   it('should open the feedback detail of a sent feedback when the recevier name is clicked in the list', async ()=> {
     fixture.debugElement.query(By.css('a')).nativeElement.click(); 

--- a/client/src/app/feedback-list/feedback-list.component.spec.ts
+++ b/client/src/app/feedback-list/feedback-list.component.spec.ts
@@ -67,7 +67,7 @@ describe('FeedbackListComponent', () => {
     component.type = FeedbackType.Received
     fixture.detectChanges()
     const senderName = fixture.debugElement.query(By.css('a'))
-    expect(senderName.nativeElement.textContent.trim()).toEqual(feedbacks[0].senderName)
+    expect(senderName.nativeElement.textContent). toContain(feedbacks[0].senderName)
   });
   it('should open the feedback detail of a sent feedback when the recevier name is clicked in the list', async ()=> {
     fixture.debugElement.query(By.css('a')).nativeElement.click(); 

--- a/client/src/app/home/home.component.spec.ts
+++ b/client/src/app/home/home.component.spec.ts
@@ -42,20 +42,17 @@ describe('HomeComponent', () => {
     expect(component).toBeTruthy();
   })
 
-  it("Send feedback button will open feedback form when it's clicked", ()=>{
+  it("Send feedback button will open feedback form when it's clicked", async ()=>{
   fixture.debugElement.query(By.css('.btn-send-margin')).nativeElement.click(); 
   fixture.detectChanges();
-  fixture.whenStable().then(() => {
-    expect(location.path()).toEqual('/send');
-    });  
-
+  await fixture.whenStable()
+  expect(location.path()).toEqual('/send');
   })
 
-  it("Ask feedback button will open ask feedback form when it's clicked", ()=>{
+  it("Ask feedback button will open ask feedback form when it's clicked", async ()=>{
     fixture.debugElement.query(By.css('.btn-ask-margin')).nativeElement.click();
     fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      expect(location.path()).toEqual('/ask');
-      });    
+    await fixture.whenStable()
+    expect(location.path()).toEqual('/ask');
     })
 });

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -11,6 +11,5 @@
   ],
   "include": [
     "src/**/*.d.ts",
-    "src/**/*.spec.ts"
   ]
 }

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -10,6 +10,7 @@
     "src/polyfills.ts"
   ],
   "include": [
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "src/**/*.spec.ts"
   ]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -32,5 +32,9 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "src/**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
Mettre en place les tests unitaires dans le composant feedback-list, les tests sont:

1- Vérifier que le template empty est affiché quand la liste est vide.
2-Vérifier que le template empty se disparaît quand la liste n'est pas vide.
3-Vérifier  que la liste est affiché quand il contient des feedbacks.
4-Vérifier que la liste des feedbacks envoyés est affichés quand l'onglet feedZbacks envoyés est cliqué.
5-Vérifier que la liste des feedbacks reçus est affichés quand l'onglet feedZbacks reçus est cliqué.
6-Il faut ouvrir la page de feedback (detail) et affiche le feedback reçus quand le sender name est cliqué.
7-Il faut ouvrir la page de feedback (detail) et afficher  le feedback envoyé quand le recever name est cliqué.
