### PR TITLE
186 return button to feedback detail

### DIFF
--- a/client/src/app/feedback/feedback.component.ts
+++ b/client/src/app/feedback/feedback.component.ts
@@ -19,9 +19,10 @@ export class FeedbackComponent implements OnInit {
   ngOnInit(): void {
     const id = this.activateRouter.snapshot.paramMap.get('id');
     this.type = this.activateRouter.snapshot.paramMap.get('type')!
-    console.log(this.type)
+   
     this.graphqlService.getFeedbackById(id!).subscribe(data => {
       this.feedback = data
+      console.log(data)
     })
 }
 }

--- a/client/src/app/feedback/feedback.component.ts
+++ b/client/src/app/feedback/feedback.component.ts
@@ -22,7 +22,6 @@ export class FeedbackComponent implements OnInit {
    
     this.graphqlService.getFeedbackById(id!).subscribe(data => {
       this.feedback = data
-      console.log(data)
     })
 }
 }

--- a/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
+++ b/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
@@ -4,9 +4,9 @@
     <h1>{{title}}</h1> 
   </div>
   <div class="result-title">{{message}}</div>
-  <button class="btn btn-primary btn-retry"  *ngIf="result === 'sendFailed'"  routerLink="/send">REESAYER</button>
-  <button class="btn btn-primary btn-retry"  *ngIf="result === 'askFailed'"  routerLink="/ask">REESAYER</button>
-  <button class="btn btn-primary btn-return" [class.btn-secondary]="result.includes('false')" routerLink={{myRouterLink}}>
-   {{send}} === true? 'Voir le feedback envoyé' : 'RETOUR À L'ACCUEIL' </button>
+  <button class="btn btn-primary btn-retry"  *ngIf="result === 'sendFailed'"  routerLink="/send">Réessayer</button>
+  <button class="btn btn-primary btn-retry"  *ngIf="result === 'askFailed'"  routerLink="/ask">Réessayer</button>
+  <button class="btn btn-primary btn-return" [class.btn-secondary]="result.includes('false')" routerLink="{{myRouterLink}}">
+   {{send === true? "Voir le feedback envoyé" : "Retour à l'accueil" }} </button>
 </div>
  

--- a/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
+++ b/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
@@ -6,6 +6,7 @@
   <div class="result-title">{{message}}</div>
   <button class="btn btn-primary btn-retry"  *ngIf="result === 'sendFailed'"  routerLink="/send">REESAYER</button>
   <button class="btn btn-primary btn-retry"  *ngIf="result === 'askFailed'"  routerLink="/ask">REESAYER</button>
-  <button class="btn btn-primary btn-return" [class.btn-secondary]="result.includes('false')" routerLink="/home">RETOUR À L'ACCUEIL</button>
+  <button class="btn btn-primary btn-return" [class.btn-secondary]="result.includes('false')" routerLink={{myRouterLink}}>
+   {{send}} === true? 'Voir le feedback envoyé' : 'RETOUR À L'ACCUEIL' </button>
 </div>
  

--- a/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
+++ b/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.html
@@ -7,6 +7,6 @@
   <button class="btn btn-primary btn-retry"  *ngIf="result === 'sendFailed'"  routerLink="/send">Réessayer</button>
   <button class="btn btn-primary btn-retry"  *ngIf="result === 'askFailed'"  routerLink="/ask">Réessayer</button>
   <button class="btn btn-primary btn-return" [class.btn-secondary]="result.includes('false')" routerLink="{{myRouterLink}}">
-   {{send === true? "Voir le feedback envoyé" : "Retour à l'accueil" }} </button>
+   {{send === true? "Voir le feedZback" : "Retour à l'accueil" }} </button>
 </div>
  

--- a/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.ts
+++ b/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.ts
@@ -14,7 +14,7 @@ export class SendAskFeedbackResultComponent implements OnInit {
   title!: string
   src!: string
   feedbackId!: string
-  myRouterLink: string = "/home"
+  myRouterLink!: string 
   constructor(private route: ActivatedRoute) {
     this.message = this.route.snapshot.paramMap.get('message')!
     this.result = this.route.snapshot.paramMap.get('result')!
@@ -30,7 +30,7 @@ export class SendAskFeedbackResultComponent implements OnInit {
     {
       this.title = 'Envoi de feedZback'
       this.src = '/assets/vector-arrow.svg'
-      this.myRouterLink = "['/feedback',feedbackId,'Sent']"
+      this.myRouterLink = `/feedback/${this.feedbackId}/Sent`
     }
      
   }

--- a/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.ts
+++ b/client/src/app/send-ask-feedback-result/send-ask-feedback-result.component.ts
@@ -13,19 +13,24 @@ export class SendAskFeedbackResultComponent implements OnInit {
   send!: boolean
   title!: string
   src!: string
+  feedbackId!: string
+  myRouterLink: string = "/home"
   constructor(private route: ActivatedRoute) {
     this.message = this.route.snapshot.paramMap.get('message')!
     this.result = this.route.snapshot.paramMap.get('result')!
+    this.feedbackId = this.route.snapshot.paramMap.get('id')!
     this.send = this.message.includes('feedback') ? true : false
     if(!this.send)
     {
       this.title = 'Demande de feedZback'
       this.src = '/assets/question-mark.svg'
+      this.myRouterLink = "/home"
     }
     else
     {
       this.title = 'Envoi de feedZback'
       this.src = '/assets/vector-arrow.svg'
+      this.myRouterLink = "['/feedback',feedbackId,'Sent']"
     }
      
   }

--- a/client/src/app/services/graphql/graphql.service.ts
+++ b/client/src/app/services/graphql/graphql.service.ts
@@ -68,9 +68,11 @@ private askFeedbackMutation = gql`
       },
     }).subscribe((data: any) => {
       let result = data.data.sendFeedback;
-      if (result === "sent") {
+      if (result.includes("sent")) {
+        const feedbackId = result.split(':')[1]
+        console.log(result + '   ' + feedbackId)
         result = "Félicitations! Votre feedback vient d’être envoyée à : " + feedback.receverName;
-        this.router.navigate(['/result', { result: 'success', message: result }])
+        this.router.navigate(['/result', { result: 'success', message: result, id: feedbackId }])
       } else {
         result = "Désolé ! Votre feedback n’a pas été envoyée à cause d’un problème technique...  Veuillez réessayer."
         this.router.navigate(['/result', { result: 'sendFailed', message: result }])

--- a/client/src/app/services/graphql/graphql.service.ts
+++ b/client/src/app/services/graphql/graphql.service.ts
@@ -12,7 +12,10 @@ import { FeedbackRequest } from 'src/app/model/feedbackRequest';
 export class GraphqlService {
  private sendFeedBackMutation = gql`
   mutation SendFeedback($feedbackInput: FeedbackInput!){
-    sendFeedback(feedbackInput:$feedbackInput)
+    sendFeedback(feedbackInput:$feedbackInput) {
+      feedbackId
+      message
+    }
   }
 `;
 
@@ -66,16 +69,16 @@ private askFeedbackMutation = gql`
       variables: {
         feedbackInput: feedback,
       },
-    }).subscribe((data: any) => {
-      let result = data.data.sendFeedback;
-      if (result.includes("sent")) {
-        const feedbackId = result.split(':')[1]
-        console.log(result + '   ' + feedbackId)
-        result = "Félicitations! Votre feedback vient d’être envoyée à : " + feedback.receverName;
-        this.router.navigate(['/result', { result: 'success', message: result, id: feedbackId }])
+    }).subscribe(({data}: any) => {
+      const result = data.sendFeedback
+      let message = result.message
+      if (message === "sent") {
+        const feedbackId = result.feedbackId
+        message = "Félicitations! Votre feedback vient d’être envoyée à : " + feedback.receverName;
+        this.router.navigate(['/result', { result: 'success', message: message, id: feedbackId }])
       } else {
-        result = "Désolé ! Votre feedback n’a pas été envoyée à cause d’un problème technique...  Veuillez réessayer."
-        this.router.navigate(['/result', { result: 'sendFailed', message: result }])
+        message = "Désolé ! Votre feedback n’a pas été envoyée à cause d’un problème technique...  Veuillez réessayer."
+        this.router.navigate(['/result', { result: 'sendFailed', message: message }])
       }
     })
   }

--- a/server/src/graphql/typeDefs.js
+++ b/server/src/graphql/typeDefs.js
@@ -37,9 +37,13 @@ input AskFeedback {
     senderEmail: String!
     text: String
 }
+type SendResult {
+    feedbackId: String
+    message: String!
+}
 
 type Mutation{
-    sendFeedback(feedbackInput: FeedbackInput!):String
-    sendFeedbackRequest(askFeedback: AskFeedback!):String
+    sendFeedback(feedbackInput: FeedbackInput!): SendResult
+    sendFeedbackRequest(askFeedback: AskFeedback!): String
 }
 `;

--- a/server/src/services/getFeedbacks.js
+++ b/server/src/services/getFeedbacks.js
@@ -47,6 +47,4 @@ export const combineEntityAndKey = (entities) => {
     list.push(res)
    }
    return list;
-
 }
-

--- a/server/src/services/sendFeedback.js
+++ b/server/src/services/sendFeedback.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 const apiKey = process.env.API_KEY;
 const domain = process.env.DOMAIN;
-let feedback;
+let feedbackId;
 
 const myMailgun = mailgun({
   apiKey: apiKey,
@@ -45,7 +45,7 @@ const insertFeedback = async (data) => {
       createdAt: Date.now()
     }
   }).then((res) => {
-    feedback =  res[0].mutationResults[0].key.path[0].id
+    feedbackId =  res[0].mutationResults[0].key.path[0].id
   })
 }
   
@@ -71,9 +71,12 @@ export const sendFeedback = async ({ feedbackInput }) => {
   try {
     await insertFeedback(feedbackInput)
     await myMailgun.messages().send(msg)
-    return "sent id:" + feedback;
-  } catch (e) {
-    console.error(e)
-    return "error"
+    const success =  {
+      feedbackId: feedbackId,
+      message: 'sent'
+    }
+    return success;
+  } catch {
+    return { message: 'error'}
   }
 };

--- a/server/src/services/sendFeedback.js
+++ b/server/src/services/sendFeedback.js
@@ -18,6 +18,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 const apiKey = process.env.API_KEY;
 const domain = process.env.DOMAIN;
+let feedback;
 
 const myMailgun = mailgun({
   apiKey: apiKey,
@@ -43,6 +44,8 @@ const insertFeedback = async (data) => {
       ...data,
       createdAt: Date.now()
     }
+  }).then((res) => {
+    feedback =  res[0].mutationResults[0].key.path[0].id
   })
 }
   
@@ -68,7 +71,7 @@ export const sendFeedback = async ({ feedbackInput }) => {
   try {
     await insertFeedback(feedbackInput)
     await myMailgun.messages().send(msg)
-    return "sent";
+    return "sent id:" + feedback;
   } catch (e) {
     console.error(e)
     return "error"


### PR DESCRIPTION
Lorsque un feedback est envoyé ou demandé, la page de résultat s'apparaît. il y avait un bouton qui permettait de retourner à l'accueil. Mais cette PR est pour le but de changer cette fonctionnalité le cas d'envoi de feedback, maintenant l'utilisateur va être diriger vers la page de détail de ce feedback.

<img width="960" alt="Screenshot 2022-08-04 at 17 07 58" src="https://user-images.githubusercontent.com/47147025/182881974-36751ef5-9bd3-4fc8-868f-6f1bb6b8e84e.png">
 