### PR TITLE
174 feedback details unit test

### DIFF
--- a/client/src/app/feedback/feedback.component.css
+++ b/client/src/app/feedback/feedback.component.css
@@ -91,9 +91,6 @@ h5 {
     display: flex;
     flex-direction: row;
 }
-.test {
-    text-align: center;
-}
 
 @media only screen and (max-width: 600px) {
     .header {

--- a/client/src/app/feedback/feedback.component.css
+++ b/client/src/app/feedback/feedback.component.css
@@ -91,6 +91,9 @@ h5 {
     display: flex;
     flex-direction: row;
 }
+.test {
+    text-align: center;
+}
 
 @media only screen and (max-width: 600px) {
     .header {

--- a/client/src/app/feedback/feedback.component.html
+++ b/client/src/app/feedback/feedback.component.html
@@ -28,7 +28,7 @@
                 <h3>Axes améliorations</h3>
                 <h4>{{feedback.toImprove}}</h4>
                 <h3 *ngIf="feedback.comment">Commentaire</h3>
-                <h4 class="test" >{{feedback.comment}}</h4>
+                <h4>{{feedback.comment}}</h4>
             </div>
         </div>  
 </div>

--- a/client/src/app/feedback/feedback.component.html
+++ b/client/src/app/feedback/feedback.component.html
@@ -17,8 +17,7 @@
                 </div>
                 <div class="first-section">
                     <h3 class="column-right">Nom de votre collègue</h3>
-                    <h4 class="column-right" *ngIf="type === 'Received'"> {{feedback.senderName}}</h4>
-                    <h4 class="column-right" *ngIf="type === 'Sent'"> {{feedback.receverName}}</h4>
+                    <h4 class="column-right"> {{ type === 'Received' ? feedback.senderName: feedback.receverName}}</h4>
                 </div>
             </div>
             <h1 *ngIf="type === 'Received'">Son retour </h1>

--- a/client/src/app/feedback/feedback.component.html
+++ b/client/src/app/feedback/feedback.component.html
@@ -28,7 +28,7 @@
                 <h3>Axes améliorations</h3>
                 <h4>{{feedback.toImprove}}</h4>
                 <h3 *ngIf="feedback.comment">Commentaire</h3>
-                <h4>{{feedback.comment}}</h4>
+                <h4 class="test" >{{feedback.comment}}</h4>
             </div>
         </div>  
 </div>

--- a/client/src/app/feedback/feedback.component.spec.ts
+++ b/client/src/app/feedback/feedback.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Apollo } from 'apollo-angular';
+import { FeedbackType } from '../enum/feedback-type';
 import { Feedback } from '../model/feedback';
 
 import { FeedbackComponent } from './feedback.component';
@@ -8,8 +10,8 @@ import { FeedbackComponent } from './feedback.component';
 describe('FeedbackComponent', () => {
   let component: FeedbackComponent;
   let fixture: ComponentFixture<FeedbackComponent>;
-  const feedback = new Feedback('1','11','Pierre','Pierre@exemple.com', 
-  'marie@example.com', 'marie', '...', '...', '...', '121212');
+  const feedback = new Feedback('1','11','Pierre','mierre@exemple.com', 
+  'marie@example.com', 'Marie', '...', '...', '...', '121212');
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,11 +26,16 @@ describe('FeedbackComponent', () => {
     fixture = TestBed.createComponent(FeedbackComponent);
     component = fixture.componentInstance;
     component.feedback = feedback;
+    component.type = 'Received'
     fixture.detectChanges();
   });
 
   it('should create', () => {
- 
     expect(component).toBeTruthy();
   });
+  it('should show sender email when the feedback type is receved', ()=> {
+    const receverEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
+    expect(receverEmail).toContain('marie@example.com')
+  })
+  
 });

--- a/client/src/app/feedback/feedback.component.spec.ts
+++ b/client/src/app/feedback/feedback.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Apollo } from 'apollo-angular';
-import { FeedbackType } from '../enum/feedback-type';
 import { Feedback } from '../model/feedback';
 
 import { FeedbackComponent } from './feedback.component';
@@ -26,7 +25,6 @@ describe('FeedbackComponent', () => {
     fixture = TestBed.createComponent(FeedbackComponent);
     component = fixture.componentInstance;
     component.feedback = feedback;
-    component.type = 'Received'
     fixture.detectChanges();
   });
 
@@ -34,14 +32,15 @@ describe('FeedbackComponent', () => {
     expect(component).toBeTruthy();
   });
   it('should show sender email when the feedback type is receved', ()=> {
-    const receverEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
-    expect(receverEmail).toContain('marie@example.com')
+    component.type = 'Received'
+    fixture.detectChanges();
+    const senderEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
+    expect(senderEmail).toContain('pierre@exemple.com')
   })
   it('should show recever email when the feedback type is sent', ()=> {
     component.type = 'Sent'
     fixture.detectChanges();
     const receverEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
-    expect(receverEmail).toContain('pierre@exemple.com')
+    expect(receverEmail).toContain('marie@example.com')
   })
-  
 });

--- a/client/src/app/feedback/feedback.component.spec.ts
+++ b/client/src/app/feedback/feedback.component.spec.ts
@@ -10,7 +10,7 @@ import { FeedbackComponent } from './feedback.component';
 describe('FeedbackComponent', () => {
   let component: FeedbackComponent;
   let fixture: ComponentFixture<FeedbackComponent>;
-  const feedback = new Feedback('1','11','Pierre','mierre@exemple.com', 
+  const feedback = new Feedback('1','11','Pierre','pierre@exemple.com', 
   'marie@example.com', 'Marie', '...', '...', '...', '121212');
 
   beforeEach(async () => {
@@ -36,6 +36,12 @@ describe('FeedbackComponent', () => {
   it('should show sender email when the feedback type is receved', ()=> {
     const receverEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
     expect(receverEmail).toContain('marie@example.com')
+  })
+  it('should show recever email when the feedback type is sent', ()=> {
+    component.type = 'Sent'
+    fixture.detectChanges();
+    const receverEmail = fixture.debugElement.query(By.css('h4')).nativeElement.textContent
+    expect(receverEmail).toContain('pierre@exemple.com')
   })
   
 });

--- a/client/src/app/feedback/feedback.component.ts
+++ b/client/src/app/feedback/feedback.component.ts
@@ -19,7 +19,6 @@ export class FeedbackComponent implements OnInit {
   ngOnInit(): void {
     const id = this.activateRouter.snapshot.paramMap.get('id');
     this.type = this.activateRouter.snapshot.paramMap.get('type')!
-    console.log(this.type)
     this.graphqlService.getFeedbackById(id!).subscribe(data => {
       this.feedback = data
     })


### PR DESCRIPTION
Mettre en place les tests unitaires par rapport aux details d'un feedback qui est ouvert à l'issue d'un clique sur la liste de feedback reçu ou envoyé.

Les tests sont faits dans le but de vérifier s'il s'agit d'un feedback de type reçu il montre bien le détail de sender et au contraire.