### PR TITLE
189 correct server url in cricle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,8 @@ jobs:
             rm temp.txt
             URL=$(echo "$URL" | cut -d':' -f2,3)    
             echo $URL 
-            sed -i "s,<SERVER_API>,$URL" app.yaml
-            cat app.yaml
+            sed -i "s,<serverApi>,$URL" src/environments/environment.prod.ts
+            cat src/environments/environment.prod.ts
             
 
   build:
@@ -255,9 +255,6 @@ workflows:
       - unit-test-server:
           requires:
              - install-client-dependencies
-      - set-serverApi-client:
-           requires:
-             - deploy-server
       - build: 
           requires:
             - install-client-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             rm temp.txt
             URL=$(echo "$URL" | cut -d':' -f2,3)    
             echo $URL 
-            sed -i "s,<serverApi>,$URL" src/environments/environment.prod.ts
+            sed  "s,<serverApi>,$URL,g" -i src/environments/environment.prod.ts
             cat src/environments/environment.prod.ts
             
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,10 @@ workflows:
       - unit-test-server:
           requires:
              - install-client-dependencies
+      - set-serverApi-client:
+          requires:
+             - deploy-server
+
       - build: 
           requires:
             - install-client-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,9 @@ workflows:
       - unit-test-server:
           requires:
              - install-client-dependencies
+      - set-serverApi-client:
+           requires:
+             - deploy-server
       - build: 
           requires:
             - install-client-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,8 @@ jobs:
             rm temp.txt
             URL=$(echo "$URL" | cut -d':' -f2,3)    
             echo $URL 
-            sed -i "s,<serverApi>,https://server-master-dot-server-service-dot-feedzback-343709.appspot.com,g" src/environments/environment.prod.ts
-            cat src/environments/environment.prod.ts
+            sed -i "s,<SERVER_API>,$URL" app.yaml
+            cat app.yaml
             
 
   build:

--- a/client/app.yaml
+++ b/client/app.yaml
@@ -15,3 +15,4 @@ handlers:
 
 env_variables:
    FIREBASE_SERVICE_KEY: <FIREBASE_SERVICE_KEY>
+   SERVER_API: <SERVER_API>

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  serverApi: process.env['SERVER_API'],
+  serverApi: 'SERVER',
   firebaseConfig: {
     apiKey: "AIzaSyAKtg1emw7hq7teSDzrhMXmh6uFWC4lDAc",
     authDomain: "feedzback-343709.firebaseapp.com",

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  serverApi: 'https://server-master-dot-server-service-dot-feedzback-343709.appspot.com/graphql',
+  serverApi: process.env['SERVER_API'],
   firebaseConfig: {
     apiKey: "AIzaSyAKtg1emw7hq7teSDzrhMXmh6uFWC4lDAc",
     authDomain: "feedzback-343709.firebaseapp.com",


### PR DESCRIPTION
J'ai trouvé l'origin de ce problème, en fait le nom des serveurs déployés ne doivent pas dépasser de 63 characters. Donc à partir de maintenant si on veut que la version de la branche déployée soit testable, il faut forcement que son nom soit vraiment court. parce-que il y a pas que son nom qui sera dans le url , c'est aussi le dot-projectId-.ew.r.appspot.com.