### PR TITLE
refresh token id before sending it to the server

### DIFF
--- a/client/src/app/ask-feedback-form/ask-feedback-form.component.ts
+++ b/client/src/app/ask-feedback-form/ask-feedback-form.component.ts
@@ -40,8 +40,8 @@ export class AskFeedbackFormComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  onSubmit() {
-    const token = sessionStorage.getItem('token');
+  async onSubmit() {
+    const token = await this.authService.getUserTokenId()
     const feedback = new FeedbackRequest(
       token!,
       this.userName,

--- a/client/src/app/send-feedback-form/send-feedback-form.component.spec.ts
+++ b/client/src/app/send-feedback-form/send-feedback-form.component.spec.ts
@@ -7,10 +7,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { AngularFireAuthModule } from '@angular/fire/compat/auth';
+import { authStub } from '../services/authStub';
 
-export const authStub =  {
-  getUserDetails: ()=> jest.fn()
-}
 describe('SendFeedbackFormComponent', () => {
   let component: SendFeedbackFormComponent;
   let fixture: ComponentFixture<SendFeedbackFormComponent>;
@@ -27,7 +25,8 @@ describe('SendFeedbackFormComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         ApolloTestingModule,
-        AngularFireAuthModule
+        AngularFireAuthModule,
+        
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();

--- a/client/src/app/send-feedback-form/send-feedback-form.component.ts
+++ b/client/src/app/send-feedback-form/send-feedback-form.component.ts
@@ -43,8 +43,8 @@ get postitiveFeedback() { return this.form.get('postitiveFeedback') }
 get toImproveFeedback() { return this.form.get('toImproveFeedback') }
 get comment() { return this.form.get('comment') }
 
-  onSubmit() {
-    const token = sessionStorage.getItem('token');
+ async onSubmit() {
+    const token = await this.authService.getUserTokenId()
     const feedback = new SendFeedback(
       token!,
       this.userName,

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -14,10 +14,7 @@ export class AuthService {
   ) {
   
     this.firebaseAuth.authState.subscribe(async user => {
-      const token = await user?.getIdToken();
-      if(token !== null)
-      sessionStorage.setItem('token', token!)
-      this.user = user 
+      this.user = user
    });
   }
 
@@ -53,9 +50,12 @@ export class AuthService {
  getFirstName() {
   return this.user?.displayName?.split(' ')[0]
  }
+  async getUserTokenId()  {
+  this.user?.refreshToken
+  return  await this.user?.getIdToken()
+ }
   signOut() {
     return this.firebaseAuth.signOut().then(() =>{
-      sessionStorage.removeItem('token');
       this.router.navigate(['sign-in'])
     })
   }

--- a/client/src/app/services/authStub.ts
+++ b/client/src/app/services/authStub.ts
@@ -6,5 +6,6 @@ export const authStub =  {
     signInWithGoogle: () => jest.fn(),
     getUserDetails: ()=> jest.fn(),
     isAnonymous: () => jest.fn(),
-    signOut: () => jest.fn()
+    signOut: () => jest.fn(),
+    getUserTokenId: () => jest.fn()
 }


### PR DESCRIPTION
Afin d'éviter l'expiration du token id de l'utilisateur. à chaque mutation requête maintenant le client rafraichir le token pour en avoir un autre à envoyer au serveur.