### PR TITLE
change import to constant Json.parser

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -12,8 +12,7 @@
     },
     "rules": {
         "max-len": "off",
-        "require-jsdoc": "off",
-        "assert": "off"
+        "require-jsdoc": "off"
     },
     "overrides": [
         {

--- a/server/index.js
+++ b/server/index.js
@@ -5,8 +5,10 @@ import {resolvers} from './src/graphql/resolvers.js';
 import cors from 'cors';
 import admin from 'firebase-admin';
 import dotEnv from 'dotenv';
-import firebaseKey from './firebase-service-key.json' assert {type: 'json'};
+import {readFileSync} from 'fs';
 
+
+const firebaseKey = JSON.parse(readFileSync('./firebase-service-key.json'));
 /**
  * configure apollo server by passing the schemas, resolvers
  */


### PR DESCRIPTION
Importer le fichier json de la clé Firebase autrement en utilisant Json.parse pour que le eslint soit content.