### PR TITLE
Debug : count each feedback once

### DIFF
--- a/usage-analytics/create-analytics/main.py
+++ b/usage-analytics/create-analytics/main.py
@@ -17,8 +17,7 @@ def create_analytics_tables(*_):
     create_daily_count = (f"""
         WITH feedbacks_creation_time AS (
             SELECT TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(data, "$.createdAt") AS INT)) AS created_time
-            FROM `{PROJECT_NAME}.firestore_export.feedback_raw_changelog`
-            WHERE operation IN ("CREATE", "IMPORT")
+            FROM `{PROJECT_NAME}.firestore_export.feedback_raw_latest`
             ),
             creation_dates AS (
             SELECT date_trunc(created_time, MONTH) AS month, DATE_TRUNC(created_time, DAY) AS day 


### PR DESCRIPTION
The analytics page states that there are 3201 feedbacks in the production database. This is wrong, there are only 201 feedbacks at the time of writing.  
This is due to the extension streaming firestore to bigquery that has run multiple imports of the same documents in the feedback_raw_changelog table. Resulting in multiple lines for one feedback.  
The view feedback_raw_latest (also built by the extension) shows the current state of the firestore db, with only one record per feedback. Using it as a source of the analytics should resolve the bug (tested in dev)


