### PR TITLE
calcul feedbacks requested and unsolicited per day and month

### DIFF
--- a/usage-analytics/create-analytics/main.py
+++ b/usage-analytics/create-analytics/main.py
@@ -15,23 +15,20 @@ def get_job_config(target_table):
 def create_analytics_tables(*_):
     client = Client(location=BIGQUERY_ZONE)
     create_daily_count = (f"""
-        WITH feedbacks_creation_time AS (
-            SELECT TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(data, "$.createdAt") AS INT)) AS created_time
-            FROM `{PROJECT_NAME}.firestore_export.feedback_raw_latest`
-            ),
-            creation_dates AS (
-            SELECT date_trunc(created_time, MONTH) AS month, DATE_TRUNC(created_time, DAY) AS day 
-            FROM feedbacks_creation_time
-            )
-        SELECT COUNT(*) AS feedbacks_created, month, day 
-        FROM creation_dates 
-        GROUP BY month, day
-             """)
+        WITH feedbacks AS (
+            SELECT DATE_TRUNC(TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(DATA, "$.createdAt") AS INT)), DAY) AS day,
+            JSON_EXTRACT_SCALAR(DATA, "$.requested") AS requested,
+            JSON_EXTRACT_SCALAR(DATA, "$.status") AS status
+            FROM `{PROJECT_NAME}.firestore_export.feedback_raw_latest`)
+        SELECT day, COUNTIF(requested="true" AND status="done") AS feedbacks_requested,COUNTIF(requested="false") AS feedbacks_unsolicited
+        FROM feedbacks
+        GROUP BY day
+            """)
     
     query_job = client.query(create_daily_count, job_config=get_job_config("daily_usage"))  
     query_job.result()
     create_monthly_count = (f"""
-        SELECT month, SUM(feedbacks_created) AS feedbacks_created
+        SELECT date_trunc(day, MONTH) AS month, SUM(feedbacks_requested) AS feedbacks_requested, SUM(feedbacks_unsolicited) AS feedbacks_unsolicited
         FROM `{PROJECT_NAME}.feedzback_usage.daily_usage`
         GROUP BY month
     """)


### PR DESCRIPTION
add a feature that calculates requested and unsolicited feedback per day and per month. This gives users an overview of the percentage of each type of feedback given over time. 