### PR TITLE
Improve dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/client"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "@typescript-eslint/*"
     groups:
       client-eslint-prettier:
         applies-to: version-updates
@@ -31,9 +33,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      tailwindcss:
+        applies-to: version-updates
+        patterns:
+          - "tailwindcss"
+          - "postcss"
+          - "autoprefixer"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 10
-    labels:
-      - dependencies
 
   - package-ecosystem: npm
     directory: "/server"
@@ -62,6 +71,3 @@ updates:
           - "minor"
           - "patch"
     open-pull-requests-limit: 10
-    labels:
-      - dependencies
-


### PR DESCRIPTION
- Add a group for `tailwindcss` related packages
- Ignore `@typescript-eslint/*` packages
- Remove the label "dependencies" (because its the default)
- Adding the label "dependencies" in the list of available labels of the project