### PR TITLE
Fix: client cookie domain

### DIFF
--- a/client/src/app/shared/i18n/language/language.service.ts
+++ b/client/src/app/shared/i18n/language/language.service.ts
@@ -1,6 +1,7 @@
 import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
 import { Injectable, LOCALE_ID, inject } from '@angular/core';
 import Cookies from 'js-cookie';
+import { environment } from '../../../../environments/environment';
 import { LOCALE_ID_COOKIE_KEY } from './language.config';
 import { AppBaseHref, LocaleId } from './language.types';
 
@@ -34,7 +35,7 @@ export class LanguageService {
   }
 
   private setCookie(localeId: LocaleId) {
-    Cookies.set(LOCALE_ID_COOKIE_KEY, localeId, { expires: 365 });
+    Cookies.set(LOCALE_ID_COOKIE_KEY, localeId, { expires: 365, domain: environment.appDomain });
   }
 
   private switchApp(newAppBaseHref: AppBaseHref) {

--- a/client/src/environments/environment.dev-local.ts
+++ b/client/src/environments/environment.dev-local.ts
@@ -14,6 +14,7 @@ const firebaseOptions: FirebaseOptions = {
 export const environment = {
   production: false,
   appVersion: APP_VERSION,
+  appDomain: 'localhost',
   firebaseOptions,
   apiBaseUrl: 'http://localhost:3000', // `dev-local` and `dev-remote` environments differ only here
   allowedEmailDomains: ['zenika.com', 'zenika.ch'],

--- a/client/src/environments/environment.dev-remote.ts
+++ b/client/src/environments/environment.dev-remote.ts
@@ -14,6 +14,7 @@ const firebaseOptions: FirebaseOptions = {
 export const environment = {
   production: false,
   appVersion: APP_VERSION,
+  appDomain: '.znk.io',
   firebaseOptions,
   apiBaseUrl: 'https://server.dev.feedzback.znk.io', // `dev-local` and `dev-remote` environments differ only here
   allowedEmailDomains: ['zenika.com', 'zenika.ch'],

--- a/client/src/environments/environment.staging.ts
+++ b/client/src/environments/environment.staging.ts
@@ -14,6 +14,7 @@ const firebaseOptions: FirebaseOptions = {
 export const environment = {
   production: false,
   appVersion: APP_VERSION,
+  appDomain: '.znk.io',
   firebaseOptions,
   apiBaseUrl: 'https://server.staging.feedzback.znk.io',
   allowedEmailDomains: ['zenika.com', 'zenika.ch'],

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -14,6 +14,7 @@ const firebaseOptions: FirebaseOptions = {
 export const environment = {
   production: true,
   appVersion: APP_VERSION,
+  appDomain: '.znk.io',
   firebaseOptions,
   apiBaseUrl: 'https://server.feedzback.znk.io',
   allowedEmailDomains: ['zenika.com', 'zenika.ch'],


### PR DESCRIPTION
The domain of the cookie "app-locale-id" is currently the client location hostname.

For example, in staging it is `feedzback.znk.io`.
That's why this cookie is not added in the HTTP requests made by the client, because the server domain is `server.feedzback.znk.io`.

To fix this problem, the domain of the client cookie must be set manually to `.znk.io`.