### PR TITLE
client,server: fix blank spaces in "positive" and "negative" feedback properties

### DIFF
--- a/client/src/app/give-feedback/shared/give-feedback-details/give-feedback-details.component.ts
+++ b/client/src/app/give-feedback/shared/give-feedback-details/give-feedback-details.component.ts
@@ -4,6 +4,7 @@ import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { LARGE_MAX_LENGTH, MEDIUM_MAX_LENGTH } from '../../../shared/feedback/feedback.config';
+import { isNotBlankValidator } from '../../../shared/validation/is-not-blank';
 import { ValidationErrorMessagePipe } from '../../../shared/validation/validation-error-message';
 
 @Component({
@@ -25,10 +26,10 @@ export class GiveFeedbackDetailsComponent implements OnInit {
   comment = input.required<FormControl<string>>();
 
   ngOnInit(): void {
-    this.positive().addValidators([Validators.required, Validators.maxLength(this.feedbackMaxLength)]);
+    this.positive().addValidators([isNotBlankValidator, Validators.maxLength(this.feedbackMaxLength)]);
     this.positive().updateValueAndValidity();
 
-    this.negative().addValidators([Validators.required, Validators.maxLength(this.feedbackMaxLength)]);
+    this.negative().addValidators([isNotBlankValidator, Validators.maxLength(this.feedbackMaxLength)]);
     this.negative().updateValueAndValidity();
 
     this.comment().addValidators([Validators.maxLength(this.commentMaxLength)]);

--- a/client/src/app/shared/validation/is-not-blank/index.ts
+++ b/client/src/app/shared/validation/is-not-blank/index.ts
@@ -1,0 +1,1 @@
+export * from './is-not-blank.validator';

--- a/client/src/app/shared/validation/is-not-blank/is-not-blank.validator.ts
+++ b/client/src/app/shared/validation/is-not-blank/is-not-blank.validator.ts
@@ -1,0 +1,13 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+/**
+ * Ensure the control value is required and not full of blank spaces
+ * (it is more restrictive than the native Angular `Validators.required`).
+ */
+export const isNotBlankValidator = (control: AbstractControl): ValidationErrors | null => {
+  const controlValue: string | null | undefined = control.value;
+  if (!controlValue || controlValue.trim() === '') {
+    return { required: true }; // Same return as native Angular `Validators.required` error
+  }
+  return null;
+};

--- a/server/src/feedback/feedback.dto.ts
+++ b/server/src/feedback/feedback.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsEmail, IsIn, IsString, MaxLength } from 'class-validator';
+import { IsBoolean, IsEmail, IsIn, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { FeedbackDraftType, FeedbackListType, FeedbackRequestDraftType } from './feedback-db';
 import { LARGE_MAX_LENGTH, MEDIUM_MAX_LENGTH, SMALL_MAX_LENGTH } from './feedback.config';
 
@@ -22,9 +22,17 @@ export class FeedbackArchiveRequestDto {
 export class GiveRequestedFeedbackDto {
   @IsString() token!: string;
 
-  @IsString() @MaxLength(LARGE_MAX_LENGTH) positive!: string;
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty()
+  @MaxLength(LARGE_MAX_LENGTH)
+  positive!: string;
 
-  @IsString() @MaxLength(LARGE_MAX_LENGTH) negative!: string;
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty()
+  @MaxLength(LARGE_MAX_LENGTH)
+  negative!: string;
 
   @IsString() @MaxLength(MEDIUM_MAX_LENGTH) comment!: string;
 }
@@ -32,9 +40,17 @@ export class GiveRequestedFeedbackDto {
 export class GiveFeedbackDto {
   @IsEmail() @Transform((params) => (params.value as string).toLowerCase()) receiverEmail!: string;
 
-  @IsString() @MaxLength(LARGE_MAX_LENGTH) positive!: string;
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty()
+  @MaxLength(LARGE_MAX_LENGTH)
+  positive!: string;
 
-  @IsString() @MaxLength(LARGE_MAX_LENGTH) negative!: string;
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty()
+  @MaxLength(LARGE_MAX_LENGTH)
+  negative!: string;
 
   @IsString() @MaxLength(MEDIUM_MAX_LENGTH) comment!: string;
 


### PR DESCRIPTION
Before, a user could send a feedback (or reply to a requested feedback) and fill the "positive" and/or "negative" fields with blank space (`"    "`).

This PR solves this problem.

On the server side, we added the following decorators in DTO : 
```ts
@Transform((params) => (params.value as string)?.trim())
@IsNotEmpty()
```

On the client side, we added a new validator `isNotBlankValidator` (and use it instead of the native Angular `Validators.required`).
