### PR TITLE
fix(client): missing asterisk to indicate mandatory fields

### DIFF
--- a/client/src/app/give-feedback/shared/give-feedback-details/give-feedback-details.component.ts
+++ b/client/src/app/give-feedback/shared/give-feedback-details/give-feedback-details.component.ts
@@ -26,10 +26,18 @@ export class GiveFeedbackDetailsComponent implements OnInit {
   comment = input.required<FormControl<string>>();
 
   ngOnInit(): void {
-    this.positive().addValidators([isNotBlankValidator, Validators.maxLength(this.feedbackMaxLength)]);
+    this.positive().addValidators([
+      Validators.required,
+      isNotBlankValidator,
+      Validators.maxLength(this.feedbackMaxLength),
+    ]);
     this.positive().updateValueAndValidity();
 
-    this.negative().addValidators([isNotBlankValidator, Validators.maxLength(this.feedbackMaxLength)]);
+    this.negative().addValidators([
+      Validators.required,
+      isNotBlankValidator,
+      Validators.maxLength(this.feedbackMaxLength),
+    ]);
     this.negative().updateValueAndValidity();
 
     this.comment().addValidators([Validators.maxLength(this.commentMaxLength)]);

--- a/client/src/app/shared/validation/is-not-blank/is-not-blank.validator.ts
+++ b/client/src/app/shared/validation/is-not-blank/is-not-blank.validator.ts
@@ -1,12 +1,30 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 
 /**
- * Ensure the control value is required and not full of blank spaces
- * (it is more restrictive than the native Angular `Validators.required`).
+ * Ensure the control value is NOT full of blank spaces
+ *
+ * @description
+ * This validator does NOT replace the native Angular `Validators.required`.
+ * It only checks that if the control value is a non-empty string, it is not composed entirely of blank spaces.
+ *
+ * This validator was designed this way to force the developer to add the native Angular `Validators.required`.
+ * It is important because Angular automatically adds an asterisk in the label of mandatory fields.
+ *
+ * @example
+ * ```ts
+ * const control = new FormControl('', [Validators.required, isNotBlankValidator]);
+ * ```
  */
 export const isNotBlankValidator = (control: AbstractControl): ValidationErrors | null => {
   const controlValue: string | null | undefined = control.value;
-  if (!controlValue || controlValue.trim() === '') {
+
+  // This validator does NOT replace the native Angular `Validators.required`.
+  // Therefore, empty string, null or undefined are all valid values.
+  if (!controlValue) {
+    return null;
+  }
+
+  if (controlValue.trim() === '') {
     return { required: true }; // Same return as native Angular `Validators.required` error
   }
   return null;


### PR DESCRIPTION
Before: asterisk KO
<img width="288" alt="Capture d’écran 2024-08-28 à 21 40 18" src="https://github.com/user-attachments/assets/8f884b5b-7e4a-4ee9-a31f-457612a4a20d">

After: asterisk OK
<img width="286" alt="Capture d’écran 2024-08-28 à 21 40 44" src="https://github.com/user-attachments/assets/46594e71-56ca-4e10-b412-4c8541794370">
