### PR TITLE
server(fix): critical auth service scope

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -6,9 +6,12 @@ import { ContextMiddleware, ContextModule } from './core/context';
 import { CryptoModule } from './core/crypto/crypto.module';
 import { GoogleApisModule } from './core/google-apis';
 import { EmployeeModule } from './employee';
+import { EmployeeController } from './employee/employee.controller';
 import { FeedbackModule } from './feedback';
+import { FeedbackController } from './feedback/feedback.controller';
 import { HealthModule } from './health';
 import { PeopleModule } from './people';
+import { PeopleController } from './people/people.controller';
 import { VersionModule } from './version';
 
 @Module({
@@ -29,6 +32,6 @@ import { VersionModule } from './version';
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(ContextMiddleware).forRoutes('');
-    consumer.apply(AuthMiddleware).forRoutes('employee', 'feedback', 'people', 'review');
+    consumer.apply(AuthMiddleware).forRoutes(EmployeeController, FeedbackController, PeopleController);
   }
 }

--- a/server/src/core/auth/auth.service.ts
+++ b/server/src/core/auth/auth.service.ts
@@ -1,8 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Scope } from '@nestjs/common';
 import { DecodedIdToken } from 'firebase-admin/auth';
 import { FirebaseService } from '../firebase';
 
-@Injectable()
+@Injectable({
+  // IMPORTANT: Provide a new instance of the provider exclusively for each incoming request.
+  // The instance should NOT be shared across incoming requests!
+  // More infos: https://docs.nestjs.com/fundamentals/injection-scopes
+  scope: Scope.REQUEST,
+})
 export class AuthService {
   private user?: DecodedIdToken | null;
 


### PR DESCRIPTION
This is a critical fix!

## The problem

The `AuthService` was not scoped to each incoming request.

This meant that if the server had to process requests from different connected users in parallel, the result was unpredictable.

Fortunately, the problem probably never occurred, as the application's traffic remains limited.

## The solution

From now on, an instance of the Auth service is created for each incoming request.