### PR TITLE
client(fix): improve wording in request feedback success page

### DIFF
--- a/client/src/app/request-feedback/request-feedback-success/request-feedback-success.component.html
+++ b/client/src/app/request-feedback/request-feedback-success/request-feedback-success.component.html
@@ -14,7 +14,9 @@
   <div class="gbl-info__buttons">
     <button mat-stroked-button routerLink="/history/type/sentRequest">
       <mat-icon>visibility</mat-icon>
-      <ng-container i18n="@@Action.ViewFeedbackRequest">Consulter la demande</ng-container>
+      <ng-container i18n="@@Component.RequestFeedbackSuccess.ViewRequests">
+        Consulter la liste des demandes
+      </ng-container>
     </button>
 
     <button mat-stroked-button routerLink="../">

--- a/client/src/locales/messages.en.json
+++ b/client/src/locales/messages.en.json
@@ -96,6 +96,7 @@
     "Component.RequestFeedback.UseTemplate": "Use a template",
     "Component.RequestFeedbackSuccess.RequestAnother": "Request another feedZback",
     "Component.RequestFeedbackSuccess.Title": "FeedZback requested from:",
+    "Component.RequestFeedbackSuccess.ViewRequests": "View list of requests",
     "Component.Settings.UpdateSuccess": "Your settings have been updated.",
     "Component.SkipLinks.Link": "Skip to main content",
     "Demo.LoremIpsum": "{$INTERPOLATION} dolor sit amet",

--- a/client/src/locales/messages.fr.json
+++ b/client/src/locales/messages.fr.json
@@ -96,6 +96,7 @@
     "Component.RequestFeedback.UseTemplate": "S'inspirer d'un modèle",
     "Component.RequestFeedbackSuccess.RequestAnother": "Demander un autre feedZback",
     "Component.RequestFeedbackSuccess.Title": "FeedZback demandé à :",
+    "Component.RequestFeedbackSuccess.ViewRequests": " Consulter la liste des demandes ",
     "Component.Settings.UpdateSuccess": "Vos paramètres ont bien été mis à jour.",
     "Component.SkipLinks.Link": "Accéder au contenu principal",
     "Demo.LoremIpsum": "{$INTERPOLATION} dolor sit amet",


### PR DESCRIPTION
Le message était auparavant : "Consulter la demande".

Mais en vérité, le lien mène vers la liste des demandes et non vers une demande en particulier.

La raison en est qu'il est possible d'envoyer une demande à plusieurs destinataires.
Et du coup, une demande distincte est créée pour chacun d'entre eux.

Le message est donc plutôt : "Consulter la liste des demandes"

<img width="824" alt="Capture d’écran 2024-09-03 à 00 17 39" src="https://github.com/user-attachments/assets/45735e2f-c812-4da0-9e8f-d40d19a10146">
