### PR TITLE
feat(#558): exclure les feedbacks non répondus du calcul des givers et receiveurs

### DIFF
--- a/usage-analytics/create-analytics/all_feedbackers.sql
+++ b/usage-analytics/create-analytics/all_feedbackers.sql
@@ -1,0 +1,22 @@
+WITH giver_emails AS (
+   SELECT 
+       DATE_TRUNC(TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(DATA, "$.createdAt") AS INT)), DAY) AS day,
+       JSON_EXTRACT_SCALAR(DATA, "$.giverEmail") AS email
+   FROM firestore_export.feedback_raw_latest
+),
+
+receiver_emails AS (
+   SELECT 
+       DATE_TRUNC(TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(DATA, "$.createdAt") AS INT)), DAY) AS day,
+       JSON_EXTRACT_SCALAR(DATA, "$.receiverEmail") AS email
+   FROM firestore_export.feedback_raw_latest
+)
+
+SELECT DISTINCT
+  day,
+  email
+FROM (
+  SELECT day, email FROM giver_emails
+  UNION ALL
+  SELECT day, email FROM receiver_emails
+) AS all_emails

--- a/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
+++ b/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
@@ -3,7 +3,9 @@ WITH feedbacks AS (
    DATE_TRUNC(TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(DATA, "$.createdAt") AS INT)), DAY) AS day,
        JSON_EXTRACT_SCALAR(DATA, "$.giverEmail") AS giverEmail,
        JSON_EXTRACT_SCALAR(DATA, "$.receiverEmail") AS receiverEmail
+
    FROM firestore_export.feedback_raw_latest
 )
 SELECT DISTINCT *
 FROM feedbacks
+WHERE JSON_EXTRACT_SCALAR(DATA, "$.status") = "done"

--- a/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
+++ b/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
@@ -1,0 +1,18 @@
+WITH feedbacks AS (
+   SELECT 
+       JSON_EXTRACT_SCALAR(DATA, "$.giverEmail") AS giverEmail,
+       JSON_EXTRACT_SCALAR(DATA, "$.receiverEmail") AS receiverEmail
+   FROM firestore_export.feedback_raw_latest
+
+),
+all_emails_feedbackers AS (
+    SELECT giverEmail AS email FROM feedbacks 
+    UNION DISTINCT
+    SELECT receiverEmail AS email FROM feedbacks
+)
+
+SELECT 
+    COUNT(DISTINCT giverEmail) AS total_givers,            -- Nombre total de givers uniques
+    COUNT(DISTINCT receiverEmail) AS total_receivers,      -- Nombre total de receivers uniques
+    COUNT(DISTINCT email) AS total_feedbackers              -- Nombre total de feedbackers (givers + receivers sans doublons)
+FROM feedbacks, all_emails_feedbackers;

--- a/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
+++ b/usage-analytics/create-analytics/feedbackers_giver_receiver_repartition.sql
@@ -1,18 +1,9 @@
 WITH feedbacks AS (
    SELECT 
+   DATE_TRUNC(TIMESTAMP_MILLIS(CAST(JSON_EXTRACT_SCALAR(DATA, "$.createdAt") AS INT)), DAY) AS day,
        JSON_EXTRACT_SCALAR(DATA, "$.giverEmail") AS giverEmail,
        JSON_EXTRACT_SCALAR(DATA, "$.receiverEmail") AS receiverEmail
    FROM firestore_export.feedback_raw_latest
-
-),
-all_emails_feedbackers AS (
-    SELECT giverEmail AS email FROM feedbacks 
-    UNION DISTINCT
-    SELECT receiverEmail AS email FROM feedbacks
 )
-
-SELECT 
-    COUNT(DISTINCT giverEmail) AS total_givers,            -- Nombre total de givers uniques
-    COUNT(DISTINCT receiverEmail) AS total_receivers,      -- Nombre total de receivers uniques
-    COUNT(DISTINCT email) AS total_feedbackers              -- Nombre total de feedbackers (givers + receivers sans doublons)
-FROM feedbacks, all_emails_feedbackers;
+SELECT DISTINCT *
+FROM feedbacks

--- a/usage-analytics/create-analytics/main.py
+++ b/usage-analytics/create-analytics/main.py
@@ -67,4 +67,7 @@ def create_analytics_tables(*_):
     execute_query("externe_feedbacks_per_month.sql", "feedzback_usage", "externe_feedbacks_per_month") 
     # This query answer the question "how many feedbacks are shared with managers each month"
     execute_query("shared_feedbacks_per_month.sql", "feedzback_usage", "shared_feedbacks_per_month") 
+    # This query answers the question: "What is the number of givers, the number of receivers, and the total number of feedbackers?"
+    execute_query("feedbackers_giver_receiver_repartition.sql", "feedzback_usage", "feedbackers_giver_receiver_repartition") 
+
     return 'OK'

--- a/usage-analytics/create-analytics/main.py
+++ b/usage-analytics/create-analytics/main.py
@@ -67,7 +67,8 @@ def create_analytics_tables(*_):
     execute_query("externe_feedbacks_per_month.sql", "feedzback_usage", "externe_feedbacks_per_month") 
     # This query answer the question "how many feedbacks are shared with managers each month"
     execute_query("shared_feedbacks_per_month.sql", "feedzback_usage", "shared_feedbacks_per_month") 
-    # This query answers the question: "What is the number of givers, the number of receivers, and the total number of feedbackers?"
+    # This query answers the question: "What is the number of givers and  the number of receivers"
     execute_query("feedbackers_giver_receiver_repartition.sql", "feedzback_usage", "feedbackers_giver_receiver_repartition") 
-
+    # This query answers the question: "What is the total number of feedbackers?"
+    execute_query("all_feedbackers.sql", "feedzback_usage", "all_feedbackers") 
     return 'OK'


### PR DESCRIPTION
Sur un feedback non répondu, on ne peut pas parler de giver et de receiveur vu que le feedbacks n'a pas encore eu lieu.