### PR TITLE
fix(server): feedback draft dto validation

### DIFF
--- a/server/src/feedback/feedback.controller.ts
+++ b/server/src/feedback/feedback.controller.ts
@@ -24,7 +24,9 @@ import {
   FeedbackListMapDto,
   FeedbackRequestAgainDto,
   FeedbackRequestDto,
+  GiveFeedbackDraftDto,
   GiveFeedbackDto,
+  GiveRequestedFeedbackDraftDto,
   GiveRequestedFeedbackDto,
   SharedFeedbackDocumentDto,
   SharedFeedbackListDto,
@@ -154,7 +156,7 @@ export class FeedbackController {
 
   @ApiOperation({ summary: 'Save the response to a requested feedback as a draft' })
   @Post('give-requested/draft')
-  async giveRequestedDraft(@Body() { token, positive, negative, comment }: GiveRequestedFeedbackDto) {
+  async giveRequestedDraft(@Body() { token, positive, negative, comment }: GiveRequestedFeedbackDraftDto) {
     const success = await this.feedbackDbService.giveRequestedDraft(token, { positive, negative, comment });
     if (!success) {
       throw new BadRequestException();
@@ -190,7 +192,7 @@ export class FeedbackController {
   @ApiOperation({ summary: 'Save a spontaneous feedback as a draft' })
   @UseGuards(AuthGuard)
   @Post('give/draft')
-  giveDraft(@Body() dto: GiveFeedbackDto) {
+  giveDraft(@Body() dto: GiveFeedbackDraftDto) {
     const giverEmail = this.authService.userEmail!;
     return this.feedbackDbService.giveDraft({ giverEmail, ...dto });
   }

--- a/server/src/feedback/feedback.dto.ts
+++ b/server/src/feedback/feedback.dto.ts
@@ -19,18 +19,17 @@ export class FeedbackArchiveRequestDto {
   @IsString() feedbackId!: string;
 }
 
-export class GiveRequestedFeedbackDto {
+// Same as `GiveRequestedFeedbackDto` but without `IsNotEmpty` additions
+export class GiveRequestedFeedbackDraftDto {
   @IsString() token!: string;
 
   @IsString()
   @Transform((params) => (params.value as string)?.trim())
-  @IsNotEmpty()
   @MaxLength(LARGE_MAX_LENGTH)
   positive!: string;
 
   @IsString()
   @Transform((params) => (params.value as string)?.trim())
-  @IsNotEmpty()
   @MaxLength(LARGE_MAX_LENGTH)
   negative!: string;
 
@@ -40,18 +39,63 @@ export class GiveRequestedFeedbackDto {
   comment!: string;
 }
 
-export class GiveFeedbackDto {
-  @IsEmail() @Transform((params) => (params.value as string).toLowerCase()) receiverEmail!: string;
+// Same as `GiveRequestedFeedbackDraftDto` but with `IsNotEmpty` additions
+export class GiveRequestedFeedbackDto {
+  @IsString() token!: string;
 
   @IsString()
   @Transform((params) => (params.value as string)?.trim())
-  @IsNotEmpty()
+  @IsNotEmpty() // Addition
   @MaxLength(LARGE_MAX_LENGTH)
   positive!: string;
 
   @IsString()
   @Transform((params) => (params.value as string)?.trim())
-  @IsNotEmpty()
+  @IsNotEmpty() // Addition
+  @MaxLength(LARGE_MAX_LENGTH)
+  negative!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @MaxLength(MEDIUM_MAX_LENGTH)
+  comment!: string;
+}
+
+// Same as `GiveFeedbackDto` but without `IsNotEmpty` additions
+export class GiveFeedbackDraftDto {
+  @IsEmail() @Transform((params) => (params.value as string).toLowerCase()) receiverEmail!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @MaxLength(LARGE_MAX_LENGTH)
+  positive!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @MaxLength(LARGE_MAX_LENGTH)
+  negative!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @MaxLength(MEDIUM_MAX_LENGTH)
+  comment!: string;
+
+  @IsBoolean() shared!: boolean;
+}
+
+// Same as `GiveFeedbackDraftDto` but with `IsNotEmpty` additions
+export class GiveFeedbackDto {
+  @IsEmail() @Transform((params) => (params.value as string).toLowerCase()) receiverEmail!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty() // Addition
+  @MaxLength(LARGE_MAX_LENGTH)
+  positive!: string;
+
+  @IsString()
+  @Transform((params) => (params.value as string)?.trim())
+  @IsNotEmpty() // Addition
   @MaxLength(LARGE_MAX_LENGTH)
   negative!: string;
 


### PR DESCRIPTION
For drafts of spontaneous feedback or responses to feedback requests:

- **Previously:** the “positive” and “negative” fields could not be left blank.
- **After:** these fields can be left blank, since this is a draft.

The but was introduced by this PR : https://github.com/Zenika/feedzback/pull/634
The usage of `@IsNotEmpty()` was applied for both non-draft (OK) and draft (KO) operations.

