### PR TITLE
e2e: fix "save as draft" in "give spontaneous feedback page" test

### DIFF
--- a/client/e2e/pages/give-spontaneous-feedback.page.ts
+++ b/client/e2e/pages/give-spontaneous-feedback.page.ts
@@ -93,6 +93,17 @@ export class GiveSpontaneousFeedbackPage {
 
   async saveAsDraft() {
     await this.page.getByRole('button', { name: 'Sauvegarder' }).click();
+
+    // IMPORTANT
+    // ---------
+    // We must wait until the notification appears because the localStorage is not cleared until the draft is fully saved.
+    //
+    // For more info, see:
+    //  -> File: src/app/give-feedback/give-feedback/give-feedback.component.ts
+    //    -> Method: onDraft()
+    //      -> Statement: this.unsavedFormService.markAsPristineAndDeleteStoredValue() // This is where the localStorage is cleared!
+    //
+    await expect(this.page.getByText('Brouillon sauvegardé.'), 'Draft saved notification should appear').toBeVisible();
   }
 
   async applyDraft(persona: Persona) {


### PR DESCRIPTION
_This is a very very long-standing error, i couldn't solve..._
_So I let Claude Code think about it for about ten seconds, and he identified the problem and provided the solution…_
_We are doomed..._

---

**Here's what Claude says:**

## Found the Issue! 🎯

This is a classic race condition in Playwright tests. Here's what's happening:

## The Problem

When you click "Save as draft", the onDraft() method:
- Calls giveFeedbackDraftService.give() - an async operation (Observable)

When the operation completes, it:
- Clears localStorage via unsavedFormService.markAsPristineAndDeleteStoredValue() (line 185)
- Shows success notification "Brouillon sauvegardé." (line 186)

In your test, you reload immediately after clicking the button:

```ts
await feedbackPage.saveAsDraft();  // Line 31 - Just clicks the button
await page.reload();               // Line 42 - Reloads IMMEDIATELY
```

Playwright is so fast that it reloads the page before the async save operation completes and clears localStorage. So the old form data is still there when the page reloads! In a real browser, humans are slow enough that by the time they manually reload, the async operation has finished. That's why it works manually but fails in Playwright.

## The Solution

Wait for the success notification before reloading. The notification "Brouillon sauvegardé." confirms that:
- The save operation completed
- localStorage was cleared

It's safe to reload

Add this to your test after saveAsDraft():

```ts
await feedbackPage.saveAsDraft();

// Wait for the success notification to confirm localStorage was cleared
await expect(
  page.getByText('Brouillon sauvegardé.'),
  'Draft saved notification should appear'
).toBeVisible();

await page.reload();
````

This ensures the localStorage clear operation has completed before reloading the page.
